### PR TITLE
Crlf fixup dev

### DIFF
--- a/Core/InnerSphereMap/StarSystems/starsystemdef_EC3040-B42A.json
+++ b/Core/InnerSphereMap/StarSystems/starsystemdef_EC3040-B42A.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "starsystemdef_EC3040-B42A",
     "Name": "EC3040-B42A",
-    "Details": "Death is like the insect \\r\\nMenacing the tree, \\r\\nCompetent to kill it, \\r\\nBut decoyed may be. \\r\\n\\r\\nBait it with the balsam, \\r\\nSeek it with the saw, \\r\\nBaffle, if it cost you \\r\\nEverything you are. \\r\\n\\r\\nThen, if it have burrowed \\r\\nOut of reach of skill, \\r\\nWring the tree and leave it, \\r\\n'Tis the vermin's will.' \\r\\n\\r\\n- Emily Dickinson, ancient Terran poet",
+    "Details": "Death is like the insect \r\nMenacing the tree, \r\nCompetent to kill it, \r\nBut decoyed may be. \r\n\r\nBait it with the balsam, \r\nSeek it with the saw, \r\nBaffle, if it cost you \r\nEverything you are. \r\n\r\nThen, if it have burrowed \r\nOut of reach of skill, \r\nWring the tree and leave it, \r\n'Tis the vermin's will.' \r\n\r\n- Emily Dickinson, ancient Terran poet",
     "Icon": ""
   },
   "Position": {

--- a/Core/InnerSphereMap/StarSystems/starsystemdef_EC3040-B43A.json
+++ b/Core/InnerSphereMap/StarSystems/starsystemdef_EC3040-B43A.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "starsystemdef_EC3040-B43A",
     "Name": "EC3040-B43A",
-    "Details": "High from the void above, \\r\\nEntropy shall claim all, \\r\\n\\r\\nInside our quiet reflections,\\r\\nSerenity rules. \\r\\n\\r\\nCall upon the loyal and, \\r\\nOut we rage against the void. \\r\\nMay the truthful word rise, \\r\\nInfinite and immovable. \\r\\nNone stand before us, \\r\\nGreatness will prevail.' \\r\\n\\r\\n- Last broadcast from DropShip Arlund's Pike II prior to loss of contact",
+    "Details": "High from the void above, \r\nEntropy shall claim all, \r\n\r\nInside our quiet reflections,\r\nSerenity rules. \r\n\r\nCall upon the loyal and, \r\nOut we rage against the void. \r\nMay the truthful word rise, \r\nInfinite and immovable. \r\nNone stand before us, \r\nGreatness will prevail.' \r\n\r\n- Last broadcast from DropShip Arlund's Pike II prior to loss of contact",
     "Icon": ""
   },
   "Position": {

--- a/Core/InnerSphereMap/StarSystems/starsystemdef_EC3040-B46A.json
+++ b/Core/InnerSphereMap/StarSystems/starsystemdef_EC3040-B46A.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "starsystemdef_EC3040-B46A",
     "Name": "EC3040-B46A",
-    "Details": "Core sampling from the Southern polar surface revealed fragments of manufactured alloys. We must note that there is no record of the world ever being settled, nor any orbital conflicts that would have scattered debris onto the surface. The samples were also found to be microscopic in size and prevalent in the planetary crust, a characteristic more in line with the outcomes of manufacturing pollution than debris fall. We strongly urge an in-depth survey of the world prior to any colonisation efforts.'\\r\\n\\r\\n- Preliminary survey report, unsealed by orders of General Vilma Alekto",
+    "Details": "Core sampling from the Southern polar surface revealed fragments of manufactured alloys. We must note that there is no record of the world ever being settled, nor any orbital conflicts that would have scattered debris onto the surface. The samples were also found to be microscopic in size and prevalent in the planetary crust, a characteristic more in line with the outcomes of manufacturing pollution than debris fall. We strongly urge an in-depth survey of the world prior to any colonisation efforts.'\r\n\r\n- Preliminary survey report, unsealed by orders of General Vilma Alekto",
     "Icon": ""
   },
   "Position": {

--- a/Core/InnerSphereMap/StarSystems/starsystemdef_EC3040-B49A.json
+++ b/Core/InnerSphereMap/StarSystems/starsystemdef_EC3040-B49A.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "starsystemdef_EC3040-B49A",
     "Name": "EC3040-B49A",
-    "Details": "QoPAYqTQjUKrbOqZMqzZno2A56PwgXCbEqG2zX2j1tGKpK9Kqf8yXfWNOqSg4eRkrscpaShB7surJhNEjmzd0VkMlSFV4LfgHvNyM0qnKtouJrk4wUWv8MERCYieCUb5GwoexVvNz9tsL3rgB9mGbF3QRHwyZFCoXHF9J2w1jUIKQ8V5b0AXHoNNUnuntOoNZRzPq8rdBDQgfINNC5LfcjZPTr7CB1VqVmc8cTGaRrwFIvUFkGIqIPF7Ay7BCBWIvmAtbB5qcbyjP7GhJZWeILgGibFr80aJdV8KIOWWSEND1jC4GrarfGjHSK3iuayvRXGrbGyfmhzDppTppI6bDjQpVq1NghsaaKJlyu5IaHIjmUdWdH16J7cws6QUgQo1UTgvXw0PsmFNp9N5UIUVd82sxYPKPNSyz3g1wYFnJYLGmjAK3Ra6E3A2xmUqnU6gAW3wsPaZkT9SpjwE9FB8tBdMJVdtubhCud0BwFiOJ00OdDFwcUjwLdhP83Vg5JR6Rd4FORCEMENTSfcKon6nEU5u7fL7sSss7CLrKcVSgyCV' \\r\\n\\r\\n- Fragmented, intercepted transmission, unknown source. Filed as evidence in Case 5579-124b, House Liao v. Tsang",
+    "Details": "QoPAYqTQjUKrbOqZMqzZno2A56PwgXCbEqG2zX2j1tGKpK9Kqf8yXfWNOqSg4eRkrscpaShB7surJhNEjmzd0VkMlSFV4LfgHvNyM0qnKtouJrk4wUWv8MERCYieCUb5GwoexVvNz9tsL3rgB9mGbF3QRHwyZFCoXHF9J2w1jUIKQ8V5b0AXHoNNUnuntOoNZRzPq8rdBDQgfINNC5LfcjZPTr7CB1VqVmc8cTGaRrwFIvUFkGIqIPF7Ay7BCBWIvmAtbB5qcbyjP7GhJZWeILgGibFr80aJdV8KIOWWSEND1jC4GrarfGjHSK3iuayvRXGrbGyfmhzDppTppI6bDjQpVq1NghsaaKJlyu5IaHIjmUdWdH16J7cws6QUgQo1UTgvXw0PsmFNp9N5UIUVd82sxYPKPNSyz3g1wYFnJYLGmjAK3Ra6E3A2xmUqnU6gAW3wsPaZkT9SpjwE9FB8tBdMJVdtubhCud0BwFiOJ00OdDFwcUjwLdhP83Vg5JR6Rd4FORCEMENTSfcKon6nEU5u7fL7sSss7CLrKcVSgyCV' \r\n\r\n- Fragmented, intercepted transmission, unknown source. Filed as evidence in Case 5579-124b, House Liao v. Tsang",
     "Icon": ""
   },
   "Position": {

--- a/Core/InnerSphereMap/StarSystems/starsystemdef_EC3040-B50A.json
+++ b/Core/InnerSphereMap/StarSystems/starsystemdef_EC3040-B50A.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "starsystemdef_EC3040-B50A",
     "Name": "EC3040-B50A",
-    "Details": "The role of the explorer is not simply the charting of unknown territories, for that is aimless wandering with extra expense. The great explorer ventures out in the interests of something bolder and larger themselves: country, unity and family. Our expedition is not in pursuit of petty glory, for we fly the colours of House Davion and we will only depart once those colours are nailed firmly to the mast, with our eyes on an endless horizon. Only then, we will do our duty, for country and countrymen.'\\r\\n\\r\\n - Proceedings from the 827th Expeditionary Planning Board, House Davion",
+    "Details": "The role of the explorer is not simply the charting of unknown territories, for that is aimless wandering with extra expense. The great explorer ventures out in the interests of something bolder and larger themselves: country, unity and family. Our expedition is not in pursuit of petty glory, for we fly the colours of House Davion and we will only depart once those colours are nailed firmly to the mast, with our eyes on an endless horizon. Only then, we will do our duty, for country and countrymen.'\r\n\r\n - Proceedings from the 827th Expeditionary Planning Board, House Davion",
     "Icon": ""
   },
   "Position": {

--- a/Core/InnerSphereMap/StarSystems/starsystemdef_EC3040-B51A.json
+++ b/Core/InnerSphereMap/StarSystems/starsystemdef_EC3040-B51A.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "starsystemdef_EC3040-B51A",
     "Name": "EC3040-B51A",
-    "Details": "Loathe the enemy within. Hate the enemy without. Fear the enemy beyond.' \\r\\n\\r\\n - Free Worlds Proverb",
+    "Details": "Loathe the enemy within. Hate the enemy without. Fear the enemy beyond.' \r\n\r\n - Free Worlds Proverb",
     "Icon": ""
   },
   "Position": {

--- a/Core/InnerSphereMap/StarSystems/starsystemdef_EC3040-B52A.json
+++ b/Core/InnerSphereMap/StarSystems/starsystemdef_EC3040-B52A.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "starsystemdef_EC3040-B52A",
     "Name": "EC3040-B52A",
-    "Details": "We don't go there anymore.'\\r\\n\\r\\n - Star Captain Myra Lakshmi, TSS Tortugan Prowler",
+    "Details": "We don't go there anymore.'\r\n\r\n - Star Captain Myra Lakshmi, TSS Tortugan Prowler",
     "Icon": ""
   },
   "Position": {


### PR DESCRIPTION
Removed over-escaped CRLFs in some Word of Blake systems.

![image](https://github.com/user-attachments/assets/6b9345b1-6820-490d-8a5a-aa223b656fd2)
